### PR TITLE
Agrego menu principal

### DIFF
--- a/main_menu.py
+++ b/main_menu.py
@@ -1,0 +1,43 @@
+def main_menu():
+    """
+    Muestra el menu principal del juego del Ahorcado y maneja las opciones seleccionadas por el usuario.
+
+    El bucle se ejecuta continuamente hasta que el usuario elige salir.
+
+    Entrada:
+    - Elige una opción ingresando el número correspondiente.
+
+    Salida:
+    - Mensajes de la opcion elegida.
+    """
+    while True:
+        print_main_menu()
+        opcion = input("Elige una opcion: ")
+        if opcion == "1":
+            print("Empezamos!")
+        elif opcion == "2":
+            print("Dificultad")
+        elif opcion == "3":
+            print("Reglas")
+        elif opcion == "4":
+            print("Adios!")
+            break
+        else:
+            print("Opcion incorrecta")
+
+
+def print_main_menu():
+    """
+    Imprime el menú principal del juego del Ahorcado.
+
+    Opciones:
+        1 - Empezar!!!!!!
+        2 - Dificultad
+        3 - Reglas
+        4 - Salir :(
+    """
+    print("Opciones:")
+    print("\t1 - Empezar!!!!!!")
+    print("\t2 - Dificultad")
+    print("\t3 - Reglas")
+    print("\t4 - Salir :(")


### PR DESCRIPTION
## Motivation

Closes #6 

## Summary of changes
- Se implementó un menú con opciones para que el jugador interactúe.
- Se añadió la función `print_main_menu()` para mostrar el menú principal.
- Se implementó el bucle `while` en la función `main_menu()` para manejar las opciones del usuario.
- Se agregaron las opciones de "Empezar", "Dificultad", "Reglas" y "Salir" al menú.
- Se creo el modulo main_menu para implementar esta issue.

## Changes
- Al elegir "Empezar", se printea: `Empezamos!`.
- Al elegir "Dificultad", se printea: `Dificultad`.
- Al elegir "Reglas", se printea: `Reglas`.
- Al elegir "Salir", se printea: `Adios!` y se sale del bucle main_menu.

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] Unit tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
