### PR TITLE
Soporte para frases y palabras

### DIFF
--- a/juego_ahorcado.py
+++ b/juego_ahorcado.py
@@ -10,7 +10,7 @@ class JuegoAhorcado:
         self.pistas_restantes = dificultad.obtener_pistas()
         self.palabra, self.pista = dificultad.obtener_palabra()
         self.mostrar_pista = False
-        self.letras_por_adivinar = list(set(self.palabra))
+        self.letras_por_adivinar = list(set(filter(lambda x: x != " ", self.palabra)))
         self.letras_adivinadas = []
         self.letras_erradas = []
         
@@ -24,6 +24,8 @@ class JuegoAhorcado:
         for letra in self.palabra:
             if letra in self.letras_adivinadas:
                 print(letra, end=" ")
+            elif letra == " ":
+                print(" ", end=" ")
             else:
                 print("_", end=" ")
     
@@ -43,6 +45,10 @@ class JuegoAhorcado:
         print("=========================================")
 
     def intentar_adivinar_letra(self, letra):
+
+        if letra.isspace():
+            return
+
         if letra in self.letras_por_adivinar:
             self.letras_por_adivinar.remove(letra)
             self.letras_adivinadas.append(letra)
@@ -56,9 +62,12 @@ class JuegoAhorcado:
         if self.intentos_restantes == 0:
             self.estado = EstadoJuego.PERDIDO
     
-    def intentar_adivinar_palabra(self, str):
+    def intentar_adivinar_palabra(self, palabra):
+
+        if palabra.isspace():
+            return
         
-        if str == self.palabra:
+        if palabra == self.palabra:
             self.estado = EstadoJuego.GANADO
         else:
             self.intentos_restantes -= 1

--- a/main_menu.py
+++ b/main_menu.py
@@ -5,7 +5,7 @@ from dificultad import Dificultad
 from enum import Enum
 
 OPCION_VOLVER_MENU_PRINCIPAL = "0"
-DIFICULTAD_INICIAL = Dificultad.NORMAL
+DIFICULTAD_INICIAL = Dificultad.DIFICIL
 
 class OpcionMenu(Enum):
     EMPEZAR_JUEGO = 1

--- a/wireframe.py
+++ b/wireframe.py
@@ -1,0 +1,156 @@
+def imprimir_victoria():
+    ahorcado = [
+        "   ___________ ",
+        "   |         |",
+        "   |         O ",
+        "   |        /|\\",
+        "   |        / \\",
+        "   |           ",
+        "   |            ",
+        "  _|_   P A L A B R A"
+    ]
+
+    for linea in ahorcado:
+        print(linea)
+
+    print("")
+
+    mensaje = [
+        "  {}{}{}    {}{}{}   {}    {}   {}{}{}   {}{}{}  {}{}{}{}{}  {}{}{}",
+        "  {}        {}    {}  {}{}  {}  {}    {}  {}          {}      {}    ",
+        "  {}  {}{}  {}{}{}{}  {} {} {}  {}{}{}{}  {}{}{}      {}      {}{}{}",
+        "  {}    {}  {}    {}  {}  {}{}  {}    {}      {}      {}      {}    ",
+        "    {}{}    {}    {}  {}    {}  {}    {}  {}{}{}      {}      {}{}{}",
+    ]
+
+    for linea in mensaje:
+        print(linea)
+
+    print("")
+
+    print("  Presione ENTER para volver al menu principal")
+    input("  Input: ")
+
+def imprimir_derrota():
+    ahorcado = [
+        "   ___________ ",
+        "   |         |",
+        "   |        _O_",
+        "   |        /|\\",
+        "   |        / \\",
+        "   |           ",
+        "   |            ",
+        "  _|_   P A L A B R A"
+    ]
+
+    for linea in ahorcado:
+        print(linea)
+
+    print("")
+
+    mensaje = [
+        "  {}{}{}   {}{}{}  {}{}{}    {}{}{}    {}  {}{}{}  {}{}{}{}{}  {}{}{}",
+        "  {}   {}  {}      {}    {}  {}    {}      {}          {}      {}    ",
+        "  {}{}{}   {}{}{}  {}{}{}    {}    {}  {}  {}{}{}      {}      {}{}{}",
+        "  {}       {}      {}  {}    {}    {}  {}      {}      {}      {}    ",
+        "  {}       {}{}{}  {}   {}   {}{}{}    {}  {}{}{}      {}      {}{}{}"
+    ]
+
+    for linea in mensaje:
+        print(linea)
+
+    print("")
+
+    print("  Presione ENTER para volver al menu principal")
+    input("  Input: ")
+
+def imprimir_1():
+    ahorcado = [
+        "   ___________ ",
+        "   |         |           Dificultad: Facil",
+        "   |         O",
+        "   |        /|\\",
+        "   |        / \\",
+        "   |           ",
+        "   |            ",
+        "  _|_    _ _ _ _ _"
+    ]
+
+    for linea in ahorcado:
+        print(linea)
+
+    print("")
+    print("  Intentos restantes: 3")
+    print("  Pistas restantes: 3")
+    print("  Letras erroneas ya mencionadas: ...")
+    print("")
+    print("  0. Volver al menu principal")
+    print("  1. Pista")
+    print("")
+    print("  Ingrese una letra o palabra")
+    print("")
+    input("  Input: ")
+
+def imprimir_2():
+    print("")
+    print("  Presione un numero para seleccionar la dificultas o volver al menu principal")
+    print("")
+    print("  1. Facil:   7 intentos, 3 pistas y palabras cortas")
+    print("  2. Medio:   5 intentos, 1 pista y palabras o frases normales")
+    print("  3. Dificil: 3 intentos, sin pistas y palabras o frases largas")
+    print("  4. Volver al menu principal")
+    print("")
+    input("  Input: ")
+
+def imprimir_3():
+    print("")
+    print("  Reglas...")
+    print("")
+    print("  Presione ENTER para volver al menu principal")
+    input("  Input: ")
+
+def imprimir_menu():
+
+    titulo = [
+        "   {}{}{}   {}    {}   {}{}   {}{}{}   {}{}{}   {}{}{}   {}{}{}     {}{}",
+        "  {}    {}  {}    {}  {}  {}  {}   {}  {}      {}    {}  {}    {}  {}  {}",
+        "  {}{}{}{}  {}{}{}{}  {}  {}  {}{}{}   {}      {}{}{}{}  {}    {}  {}  {}",
+        "  {}    {}  {}    {}  {}  {}  {}  {}   {}      {}    {}  {}    {}  {}  {}",
+        "  {}    {}  {}    {}   {}{}   {}   {}  {}{}{}  {}    {}  {}{}{}     {}{}"
+    ]
+
+    print("")
+
+    for linea in titulo:
+        print(linea)
+
+    print("")
+
+    ahorcado = [
+        "   ___________",
+        "   |         |",
+        "   |         O",
+        "   |        /|\\",
+        "   |        / \\",
+        "  _|_"
+    ]
+
+    for linea in ahorcado:
+        print(linea)
+
+    print("")
+
+    print("  1. Empezar partida")
+    print("  2. Seleccionar nivel de dificultad")
+    print("  3. Reglas del juego")
+    print("  4. Salir")
+    print("")
+    input("  Input: ")
+
+# imprimir_menu()
+
+# imprimir_1()
+# imprimir_2()
+# imprimir_3()
+# imprimir_derrota()
+# imprimir_victoria()


### PR DESCRIPTION
Si bien antes de trabajar en esta issue en el juego aparecían tanto frases como palabras, el juego no distinguía entre letras y espacios. Entonces se implemento la lógica para dejar afuera los espacios y que estos no sean adivinables. 

Para dejar afuera los espacios en blanco de las palabras, estos se imprimen por pantalla como espacios y no como '_'.

Para que no sean adivinables los espacios en blanco de las palabras, en la lista de letras por adivinar que tiene el juego se filtran los espacios en blanco como lo indicaba la issue.

Ademas, si el jugador ingresa un espacio en blanco o muchos espacios en blanco concatenados por error no se disminuirán sus intentos restantes.